### PR TITLE
EngineDiscoveryRequestResolver in Test Discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To use it for ScalaTest 3.2.16 and JUnit 5.9:
 SBT:
 
 ```
-libraryDependencies += "org.scalatestplus" %% "junit-5-9" % "3.2.16.0-M1" % Test
+libraryDependencies += "org.scalatestplus" %% "junit-5-9" % "3.2.16.0-M3" % Test
 ```
 
 Maven:
@@ -17,7 +17,7 @@ Maven:
 <dependency>
   <groupId>org.scalatestplus</groupId>
   <artifactId>junit-5-9_2.13</artifactId>
-  <version>3.2.16.0-M1</version>
+  <version>3.2.16.0-M3</version>
   <scope>test</scope>
 </dependency>
 ```

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Maven:
 </dependency>
 ```
 
+**Note on Gradle Project's Default Test Runner on IntelliJ IDEA**
+
+For Gradle project, by default IntelliJ IDEA uses Gradle's test runner to run tests, which at the time of writing does not work with `Jump to Source` feature.  You may switch to use IntelliJ IDEA's test runner by following the instructions [here](https://www.jetbrains.com/help/idea/work-with-tests-in-gradle.html#configure_gradle_test_runner).
+
 **Publishing**
 
 Please use the following commands to publish to Sonatype:

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "junit-5.9"
 
 organization := "org.scalatestplus"
 
-version := "3.2.16.0-M4"
+version := "3.2.16.0-M5"
 
 homepage := Some(url("https://github.com/scalatest/scalatestplus-junit"))
 

--- a/build.sbt
+++ b/build.sbt
@@ -29,12 +29,14 @@ developers := List(
 scalaVersion := "2.13.11"
 
 crossScalaVersions := List(
-  //"2.10.7",
-  //"2.11.12",
-  //"2.12.18",
+  "2.10.7",
+  "2.11.12",
+  "2.12.18",
   "2.13.11", 
   "3.1.3"
 )
+
+scalacOptions ++= Seq("-target:jvm-1.8")
 
 /** Add src/main/scala-{2|3} to Compile / unmanagedSourceDirectories */
 Compile / unmanagedSourceDirectories ++= {

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "junit-5.9"
 
 organization := "org.scalatestplus"
 
-version := "3.2.16.0-M3"
+version := "3.2.16.0-M4"
 
 homepage := Some(url("https://github.com/scalatest/scalatestplus-junit"))
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "junit-5.9"
 
 organization := "org.scalatestplus"
 
-version := "3.2.16.0-M2"
+version := "3.2.16.0-M3"
 
 homepage := Some(url("https://github.com/scalatest/scalatestplus-junit"))
 
@@ -29,9 +29,9 @@ developers := List(
 scalaVersion := "2.13.11"
 
 crossScalaVersions := List(
-  "2.10.7", 
-  "2.11.12", 
-  "2.12.18", 
+  //"2.10.7",
+  //"2.11.12",
+  //"2.12.18",
   "2.13.11", 
   "3.1.3"
 )

--- a/examples/gradle-example/build.gradle
+++ b/examples/gradle-example/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation "org.scalatest:scalatest_2.12:3.2.16"
     testImplementation "org.junit.platform:junit-platform-launcher:1.9.1"
     testRuntimeOnly "org.junit.platform:junit-platform-engine:1.9.1"
-    testRuntimeOnly "org.scalatestplus:junit-5-9_2.12:3.2.16.0-M3"
+    testRuntimeOnly "org.scalatestplus:junit-5-9_2.12:3.2.16.0-M4"
 }
 
 test {

--- a/examples/gradle-example/build.gradle
+++ b/examples/gradle-example/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation "org.scalatest:scalatest_2.12:3.2.16"
     testImplementation "org.junit.platform:junit-platform-launcher:1.9.1"
     testRuntimeOnly "org.junit.platform:junit-platform-engine:1.9.1"
-    testRuntimeOnly "org.scalatestplus:junit-5-9_2.12:3.2.16.0-M4"
+    testRuntimeOnly "org.scalatestplus:junit-5-9_2.12:3.2.16.0-M5"
 }
 
 test {

--- a/examples/gradle-example/build.gradle
+++ b/examples/gradle-example/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation "org.scalatest:scalatest_2.12:3.2.16"
     testImplementation "org.junit.platform:junit-platform-launcher:1.9.1"
     testRuntimeOnly "org.junit.platform:junit-platform-engine:1.9.1"
-    testRuntimeOnly "org.scalatestplus:junit-5-9_2.12:3.2.16.0-M1"
+    testRuntimeOnly "org.scalatestplus:junit-5-9_2.12:3.2.16.0-M3"
 }
 
 test {

--- a/examples/gradle-example/src/test/scala/co/helmethair/scalatest/example/SkipWithScalaTag.scala
+++ b/examples/gradle-example/src/test/scala/co/helmethair/scalatest/example/SkipWithScalaTag.scala
@@ -10,7 +10,7 @@ class SkipWithScalaTag extends AnyFunSpec with Matchers {
 
     }
     it("assert two") {
-
+      fail
     }
   }
 

--- a/examples/gradle-kotlin-dsl-example/build.gradle.kts
+++ b/examples/gradle-kotlin-dsl-example/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     testImplementation("org.scalatest:scalatest_2.12:3.2.16")
     testRuntimeOnly("org.junit.platform:junit-platform-engine:1.9.1")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.9.1")
-    testRuntimeOnly("org.scalatestplus:junit-5-9_2.12:3.2.16.0-M1")
+    testRuntimeOnly("org.scalatestplus:junit-5-9_2.12:3.2.16.0-M3")
 }
 
 tasks {

--- a/examples/gradle-kotlin-dsl-example/build.gradle.kts
+++ b/examples/gradle-kotlin-dsl-example/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     testImplementation("org.scalatest:scalatest_2.12:3.2.16")
     testRuntimeOnly("org.junit.platform:junit-platform-engine:1.9.1")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.9.1")
-    testRuntimeOnly("org.scalatestplus:junit-5-9_2.12:3.2.16.0-M4")
+    testRuntimeOnly("org.scalatestplus:junit-5-9_2.12:3.2.16.0-M5")
 }
 
 tasks {

--- a/examples/gradle-kotlin-dsl-example/build.gradle.kts
+++ b/examples/gradle-kotlin-dsl-example/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     testImplementation("org.scalatest:scalatest_2.12:3.2.16")
     testRuntimeOnly("org.junit.platform:junit-platform-engine:1.9.1")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.9.1")
-    testRuntimeOnly("org.scalatestplus:junit-5-9_2.12:3.2.16.0-M3")
+    testRuntimeOnly("org.scalatestplus:junit-5-9_2.12:3.2.16.0-M4")
 }
 
 tasks {

--- a/examples/maven-example/pom.xml
+++ b/examples/maven-example/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.scalatestplus</groupId>
             <artifactId>junit-5-9_${scala.compat.version}</artifactId>
-            <version>${scalatest.version}.0-M1</version>
+            <version>${scalatest.version}.0-M3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/maven-example/pom.xml
+++ b/examples/maven-example/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.scalatestplus</groupId>
             <artifactId>junit-5-9_${scala.compat.version}</artifactId>
-            <version>${scalatest.version}.0-M3</version>
+            <version>${scalatest.version}.0-M4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/maven-example/pom.xml
+++ b/examples/maven-example/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.scalatestplus</groupId>
             <artifactId>junit-5-9_${scala.compat.version}</artifactId>
-            <version>${scalatest.version}.0-M4</version>
+            <version>${scalatest.version}.0-M5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/scala/org/scalatestplus/junit5/ScalaTestClassDescriptor.scala
+++ b/src/main/scala/org/scalatestplus/junit5/ScalaTestClassDescriptor.scala
@@ -16,7 +16,9 @@
 package org.scalatestplus.junit5
 
 import org.junit.platform.engine.support.descriptor.{AbstractTestDescriptor, ClassSource}
-import org.junit.platform.engine.{TestDescriptor, UniqueId}
+import org.junit.platform.engine.{TestDescriptor, TestSource, UniqueId}
+
+import java.util.Optional
 
 /**
  * <code>TestDescriptor</code> for ScalaTest suite.
@@ -34,6 +36,9 @@ class ScalaTestClassDescriptor(parent: TestDescriptor, val theUniqueId: UniqueId
   override def getType: TestDescriptor.Type = TestDescriptor.Type.CONTAINER
 
   override def mayRegisterTests(): Boolean = true
+
+  override def getSource: Optional[TestSource] =
+    Optional.of(ClassSource.from(suiteClass))
 }
 
 object ScalaTestClassDescriptor {

--- a/src/main/scala/org/scalatestplus/junit5/ScalaTestDescriptor.scala
+++ b/src/main/scala/org/scalatestplus/junit5/ScalaTestDescriptor.scala
@@ -41,7 +41,21 @@ class ScalaTestDescriptor(theUniqueId: UniqueId, displayName: String, locationOp
       locationOpt.map { loc =>
         loc match {
           case TopOfClass(className) => ClassSource.from(className)
-          case TopOfMethod(className, methodId) => MethodSource.from(className, methodId)
+          case TopOfMethod(className, methodId) =>
+            val openingBracketIdx = methodId.indexOf("(")
+            val closingBracketIdx = methodId.indexOf(")")
+            if (openingBracketIdx >= 0 && closingBracketIdx >= 0) {
+              val beforeOpeningBracket = methodId.substring(0, openingBracketIdx)
+              val lastSpaceIdx = beforeOpeningBracket.lastIndexOf(" ")
+              val methodNameWithClassName = if (lastSpaceIdx >= 0) beforeOpeningBracket.substring(lastSpaceIdx + 1) else beforeOpeningBracket
+              val methodNameLastDotIdx = methodNameWithClassName.lastIndexOf(".")
+              val methodName = if (methodNameLastDotIdx >= 0) methodNameWithClassName.substring(methodNameLastDotIdx + 1) else methodNameWithClassName
+              val methodArgs = methodId.substring(openingBracketIdx + 1, closingBracketIdx)
+              if (methodArgs.trim.isEmpty) MethodSource.from(className, methodName) else MethodSource.from(className, methodName, methodArgs)
+            }
+            else
+              MethodSource.from(className, methodId)
+
           case LineInFile(lineNumber: Int, fileName: String, filePathname: Option[String]) => FileSource.from(new File(filePathname.getOrElse(fileName)), FilePosition.from(lineNumber))
           case SeeStackDepthException => ClassSource.from(theUniqueId.getSegments.get(1).getValue) // Let's just refer to the class for SeeStackDepthException
         }

--- a/src/main/scala/org/scalatestplus/junit5/ScalaTestEngine.scala
+++ b/src/main/scala/org/scalatestplus/junit5/ScalaTestEngine.scala
@@ -29,8 +29,10 @@ import org.scalatest.{Args, ConfigMap, DynaTags, Filter, Stopper, Tracker}
 import java.util.Optional
 import java.util.function.Supplier
 import java.util.logging.Logger
-import scala.jdk.CollectionConverters._
-import scala.jdk.OptionConverters._
+import java.util.stream.Collectors
+//import scala.jdk.CollectionConverters._
+//import scala.jdk.OptionConverters._
+import scala.collection.JavaConverters._
 import scala.reflect.NameTransformer
 
 /**
@@ -72,7 +74,7 @@ class ScalaTestEngine extends org.junit.platform.engine.TestEngine {
         override def resolve(selector: ClasspathRootSelector, context: SelectorResolver.Context): SelectorResolver.Resolution = {
           val matches =
             ReflectionSupport.findAllClassesInClasspathRoot(selector.getClasspathRoot, isSuitePredicate, alwaysTruePredicate)
-              .asScala
+              .stream()
               .flatMap { aClass =>
                 context.addToParent((parent: TestDescriptor) => {
                   val suiteUniqueId = parent.getUniqueId.append(ScalaTestClassDescriptor.segmentType, aClass.getName)
@@ -82,15 +84,15 @@ class ScalaTestEngine extends org.junit.platform.engine.TestEngine {
                   }
                 }).map { it =>
                   Match.exact(it)
-                }.toScala
-              }.toSet
-          Resolution.matches(matches.asJava)
+                }.map(java.util.stream.Stream.of[Match]).orElse(java.util.stream.Stream.empty())
+              }.collect(Collectors.toSet())
+          Resolution.matches(matches)
         }
 
         override def resolve(selector: PackageSelector, context: SelectorResolver.Context): SelectorResolver.Resolution = {
           val matches =
             ReflectionSupport.findAllClassesInPackage(selector.getPackageName, isSuitePredicate, alwaysTruePredicate)
-              .asScala
+              .stream()
               .flatMap { aClass =>
                 context.addToParent((parent: TestDescriptor) => {
                   val suiteUniqueId = parent.getUniqueId.append(ScalaTestClassDescriptor.segmentType, aClass.getName)
@@ -100,9 +102,9 @@ class ScalaTestEngine extends org.junit.platform.engine.TestEngine {
                   }
                 }).map { it =>
                   Match.exact(it)
-                }.toScala
-              }.toSet
-          Resolution.matches(matches.asJava)
+                }.map(java.util.stream.Stream.of[Match]).orElse(java.util.stream.Stream.empty())
+              }.collect(Collectors.toSet())
+          Resolution.matches(matches)
         }
 
         override def resolve(selector: ClassSelector, context: SelectorResolver.Context): SelectorResolver.Resolution = {

--- a/src/main/scala/org/scalatestplus/junit5/ScalaTestEngine.scala
+++ b/src/main/scala/org/scalatestplus/junit5/ScalaTestEngine.scala
@@ -158,7 +158,7 @@ class ScalaTestEngine extends org.junit.platform.engine.TestEngine {
                       val children = parent.getChildren.asScala
                       val suiteUniqueId = uniqueId.append(ScalaTestClassDescriptor.segmentType, suiteClass.getName)
                       val testUniqueId = suiteUniqueId.append("test", testSeg.getValue)
-                      val testDesc = new ScalaTestDescriptor(testUniqueId, testSeg.getValue)
+                      val testDesc = new ScalaTestDescriptor(testUniqueId, testSeg.getValue, None)
                       val (suiteDesc, result) =
                         children.find(_.getUniqueId == suiteUniqueId) match {
                           case Some(suiteDesc) =>

--- a/src/main/scala/org/scalatestplus/junit5/ScalaTestEngine.scala
+++ b/src/main/scala/org/scalatestplus/junit5/ScalaTestEngine.scala
@@ -82,9 +82,9 @@ class ScalaTestEngine extends org.junit.platform.engine.TestEngine {
                     case Some(_) => Optional.empty[ScalaTestClassDescriptor]()
                     case None => Optional.of(new ScalaTestClassDescriptor(engineDesc, suiteUniqueId, aClass))
                   }
-                }).map { it =>
+                }).map[Match] { it =>
                   Match.exact(it)
-                }.map(java.util.stream.Stream.of[Match]).orElse(java.util.stream.Stream.empty())
+                }.map[java.util.stream.Stream[Match]](java.util.stream.Stream.of[Match]).orElse(java.util.stream.Stream.empty())
               }.collect(Collectors.toSet())
           Resolution.matches(matches)
         }
@@ -100,9 +100,9 @@ class ScalaTestEngine extends org.junit.platform.engine.TestEngine {
                     case Some(_) => Optional.empty[ScalaTestClassDescriptor]()
                     case None => Optional.of(new ScalaTestClassDescriptor(engineDesc, suiteUniqueId, aClass))
                   }
-                }).map { it =>
+                }).map[Match] { it =>
                   Match.exact(it)
-                }.map(java.util.stream.Stream.of[Match]).orElse(java.util.stream.Stream.empty())
+                }.map[java.util.stream.Stream[Match]](java.util.stream.Stream.of[Match]).orElse(java.util.stream.Stream.empty())
               }.collect(Collectors.toSet())
           Resolution.matches(matches)
         }
@@ -116,7 +116,7 @@ class ScalaTestEngine extends org.junit.platform.engine.TestEngine {
                 case Some(_) => Optional.empty[ScalaTestClassDescriptor]()
                 case None => Optional.of(new ScalaTestClassDescriptor(engineDesc, suiteUniqueId, testClass))
               }
-            }).map { it =>
+            }).map[Resolution] { it =>
               Resolution.`match`(Match.exact(it))
             }.orElse(Resolution.unresolved())
           }
@@ -153,7 +153,7 @@ class ScalaTestEngine extends org.junit.platform.engine.TestEngine {
                   }
 
                   result
-                }).map { it =>
+                }).map[Resolution] { it =>
                   Resolution.`match`(Match.exact(it))
                 }.orElse(Resolution.unresolved())
               }
@@ -171,7 +171,7 @@ class ScalaTestEngine extends org.junit.platform.engine.TestEngine {
                     case Some(_) => Optional.empty[ScalaTestClassDescriptor]()
                     case None => Optional.of(new ScalaTestClassDescriptor(engineDesc, suiteUniqueId, suiteClass))
                   }
-                }).map { it =>
+                }).map[Resolution] { it =>
                   Resolution.`match`(Match.exact(it))
                 }.orElse(Resolution.unresolved())
               }

--- a/src/main/scala/org/scalatestplus/junit5/ScalaTestEngine.scala
+++ b/src/main/scala/org/scalatestplus/junit5/ScalaTestEngine.scala
@@ -15,23 +15,17 @@
  */
 package org.scalatestplus.junit5
 
-import org.junit.jupiter.api.ClassDescriptor
 import org.junit.platform.commons.support.ReflectionSupport
-import org.junit.platform.engine.TestDescriptor.Visitor
-import org.junit.platform.engine.discovery.{ClassSelector, ClasspathRootSelector, FileSelector, ModuleSelector, PackageSelector, UniqueIdSelector}
+import org.junit.platform.engine.discovery.{ClassSelector, ClasspathRootSelector, ModuleSelector, PackageSelector, UniqueIdSelector}
 import org.junit.platform.engine.support.descriptor.EngineDescriptor
-import org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolver.InitializationContext
-import org.junit.platform.engine.support.discovery.SelectorResolver.{Context, Match, Resolution}
+import org.junit.platform.engine.support.discovery.SelectorResolver.{Match, Resolution}
 import org.junit.platform.engine.support.discovery.{EngineDiscoveryRequestResolver, SelectorResolver}
 import org.junit.platform.engine.{EngineDiscoveryRequest, ExecutionRequest, TestDescriptor, TestExecutionResult, UniqueId}
 import org.scalatest.{Args, ConfigMap, DynaTags, Filter, Stopper, Tracker}
 
 import java.util.Optional
-import java.util.function.Supplier
 import java.util.logging.Logger
 import java.util.stream.Collectors
-//import scala.jdk.CollectionConverters._
-//import scala.jdk.OptionConverters._
 import scala.collection.JavaConverters._
 import scala.reflect.NameTransformer
 

--- a/src/main/scala/org/scalatestplus/junit5/ScalaTestEngine.scala
+++ b/src/main/scala/org/scalatestplus/junit5/ScalaTestEngine.scala
@@ -18,7 +18,7 @@ package org.scalatestplus.junit5
 import org.junit.jupiter.api.ClassDescriptor
 import org.junit.platform.commons.support.ReflectionSupport
 import org.junit.platform.engine.TestDescriptor.Visitor
-import org.junit.platform.engine.discovery.{ClassSelector, ClasspathRootSelector, FileSelector, PackageSelector, UniqueIdSelector}
+import org.junit.platform.engine.discovery.{ClassSelector, ClasspathRootSelector, FileSelector, ModuleSelector, PackageSelector, UniqueIdSelector}
 import org.junit.platform.engine.support.descriptor.EngineDescriptor
 import org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolver.InitializationContext
 import org.junit.platform.engine.support.discovery.SelectorResolver.{Context, Match, Resolution}
@@ -112,6 +112,15 @@ class ScalaTestEngine extends org.junit.platform.engine.TestEngine {
         override def resolve(selector: PackageSelector, context: SelectorResolver.Context): SelectorResolver.Resolution = {
           val matches =
             ReflectionSupport.findAllClassesInPackage(selector.getPackageName, isSuitePredicate, alwaysTruePredicate)
+              .stream()
+              .flatMap(addToParentFunction(context))
+              .collect(Collectors.toSet())
+          Resolution.matches(matches)
+        }
+
+        override def resolve(selector: ModuleSelector, context: SelectorResolver.Context): SelectorResolver.Resolution = {
+          val matches =
+            ReflectionSupport.findAllClassesInModule(selector.getModuleName, isSuitePredicate, alwaysTruePredicate)
               .stream()
               .flatMap(addToParentFunction(context))
               .collect(Collectors.toSet())

--- a/src/test/scala/org/scalatestplus/junit5/ScalaTestDescriptorSpec.scala
+++ b/src/test/scala/org/scalatestplus/junit5/ScalaTestDescriptorSpec.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2001-2023 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatestplus.junit5
+
+import org.scalatest._
+import org.scalatest.events._
+import org.junit.platform.engine.UniqueId
+import org.junit.platform.engine.support.descriptor.{ClassSource, FilePosition, FileSource, MethodSource}
+
+import java.io.File
+
+class ScalaTestDescriptorSpec extends funspec.AnyFunSpec {
+
+  val uniqueId = UniqueId.forEngine("ScalaTestEngine")
+  val displayName = "Test"
+  val className = "org.example.TestClass"
+  val methodName = "testMethod"
+  val methodArgs = "arg1, arg2"
+  val lineNumber = 42
+  val fileName = "TestFile.scala"
+  val filePathname = Some("/path/to/TestFile.scala")
+
+  describe("ScalaTestDescriptor") {
+
+    describe("getSource method") {
+
+      it("should return ClassSource when location is TopOfClass") {
+        val locationOpt = Some(TopOfClass(className))
+        val descriptor1 = new ScalaTestDescriptor(uniqueId.append(ScalaTestClassDescriptor.segmentType, className).append("test", displayName), displayName, locationOpt)
+        assert(descriptor1.getSource.isPresent)
+        assert(descriptor1.getSource.get() == ClassSource.from(className))
+      }
+
+      it("should return MethodSource when location is TopOfMethod") {
+        val descriptor1 = new ScalaTestDescriptor(uniqueId.append(ScalaTestClassDescriptor.segmentType, className).append("test", displayName), displayName,
+                                                  Some(TopOfMethod(className, "public long java.util.concurrent.CountDownLatch.getCount()")))
+        assert(descriptor1.getSource.isPresent)
+        assert(descriptor1.getSource.get() == MethodSource.from(className, "getCount"))
+
+        val descriptor2 = new ScalaTestDescriptor(uniqueId.append(ScalaTestClassDescriptor.segmentType, className).append("test", displayName), displayName,
+          Some(TopOfMethod(className, "public final void java.lang.Object.wait(long,int) throws java.lang.InterruptedException")))
+        assert(descriptor2.getSource.isPresent)
+        assert(descriptor2.getSource.get() == MethodSource.from(className, "wait", "long,int"))
+
+        val descriptor3 = new ScalaTestDescriptor(uniqueId.append(ScalaTestClassDescriptor.segmentType, className).append("test", displayName), displayName,
+          Some(TopOfMethod(className, "public boolean java.lang.Object.equals(java.lang.Object)")))
+        assert(descriptor3.getSource.isPresent)
+        assert(descriptor3.getSource.get() == MethodSource.from(className, "equals", "java.lang.Object"))
+      }
+
+      it("should return FileSource when location is LineInFile") {
+        val locationOpt = Some(LineInFile(lineNumber, fileName, filePathname))
+        val descriptor1 = new ScalaTestDescriptor(uniqueId.append(ScalaTestClassDescriptor.segmentType, className).append("test", displayName), displayName, locationOpt)
+        assert(descriptor1.getSource.isPresent)
+        assert(descriptor1.getSource.get() == FileSource.from(new File(filePathname.getOrElse(fileName)), FilePosition.from(lineNumber)))
+      }
+
+      it("should return ClassSource when location is SeeStackDepthException") {
+        val locationOpt = Some(SeeStackDepthException)
+        val descriptor1 = new ScalaTestDescriptor(uniqueId.append(ScalaTestClassDescriptor.segmentType, className).append("test", displayName), displayName, locationOpt)
+        assert(descriptor1.getSource.isPresent)
+        assert(descriptor1.getSource.get() == ClassSource.from(className))
+      }
+
+      it("should return Optional.empty when location is None") {
+        val locationOpt = None
+        val descriptor1 = new ScalaTestDescriptor(uniqueId.append(ScalaTestClassDescriptor.segmentType, className).append("test", displayName), displayName, locationOpt)
+        assert(!descriptor1.getSource.isPresent)
+      }
+
+    }
+
+  }
+}


### PR DESCRIPTION
Changed to use EngineDiscoveryRequestResolver in test discovery, this PR has been released as M3.