### PR TITLE
Wait for tests to finish before continuing

### DIFF
--- a/src/main/scala/org/scalatestplus/junit5/ScalaTestEngine.scala
+++ b/src/main/scala/org/scalatestplus/junit5/ScalaTestEngine.scala
@@ -279,9 +279,10 @@ class ScalaTestEngine extends org.junit.platform.engine.TestEngine {
                   )
               }
 
-            suiteToRun.run(None, Args(reporter,
+            val status = suiteToRun.run(None, Args(reporter,
               Stopper.default, filter, ConfigMap.empty, None,
               new Tracker))
+            status.waitUntilCompleted()
 
             listener.executionFinished(clzDesc, TestExecutionResult.successful())
 


### PR DESCRIPTION
This fixes an issue where the results are ignored when running an asynchronous test class (e.g. `with AsyncFlatSpec`). For them, calling `suiteToRun.run` returns quickly, but the tests are only complete (with the relevant test events handled) once the returned status has become "complete".