### PR TITLE
Fix extracting payload from throwable

### DIFF
--- a/src/main/scala/org/scalatestplus/junit5/JUnitExecutionListener.scala
+++ b/src/main/scala/org/scalatestplus/junit5/JUnitExecutionListener.scala
@@ -51,7 +51,7 @@ private[junit5] class JUnitExecutionListener(report: Reporter,
         val message = throwable.map(_.toString).getOrElse(Resources.jUnitTestFailed())
         val formatter = getIndentedTextForTest(testName, 1, true)
         val payload =
-          throwable match {
+          throwable.flatMap {
             case optPayload: PayloadField =>
               optPayload.payload
             case _ =>


### PR DESCRIPTION
Previously this code was checking if `Some[Throwable]` can be matched with `PayloadField`, which will never happen. We should be matching `Throwable` to `PayloadField`.