### PR TITLE
Return unresolved when tests not found during discovery

### DIFF
--- a/src/main/scala/org/scalatestplus/junit5/ScalaTestEngine.scala
+++ b/src/main/scala/org/scalatestplus/junit5/ScalaTestEngine.scala
@@ -55,7 +55,7 @@ class ScalaTestEngine extends org.junit.platform.engine.TestEngine {
     val engineDesc = new EngineDescriptor(uniqueId, "ScalaTest EngineDescriptor")
 
     if (System.getProperty("org.scalatestplus.junit5.ScalaTestEngine.disabled") != "true") {
-      logger.info("Starting test discovery...")
+      logger.fine("Starting test discovery...")
 
       val alwaysTruePredicate =
         new java.util.function.Predicate[String]() {
@@ -234,7 +234,7 @@ class ScalaTestEngine extends org.junit.platform.engine.TestEngine {
 
       resolver.resolve(discoveryRequest, engineDesc)
 
-      logger.info("Completed test discovery, discovered suite count: " + engineDesc.getChildren.size())
+      logger.config("Completed test discovery, discovered suite count: " + engineDesc.getChildren.size())
     }
 
     engineDesc
@@ -245,7 +245,7 @@ class ScalaTestEngine extends org.junit.platform.engine.TestEngine {
    */
   def execute(request: ExecutionRequest): Unit = {
     if (System.getProperty("org.scalatestplus.junit5.ScalaTestEngine.disabled") != "true") {
-      logger.info("Start tests execution...")
+      logger.fine("Start tests execution...")
       val engineDesc = request.getRootTestDescriptor
       val listener = request.getEngineExecutionListener
 
@@ -253,7 +253,7 @@ class ScalaTestEngine extends org.junit.platform.engine.TestEngine {
       engineDesc.getChildren.asScala.foreach { testDesc =>
         testDesc match {
           case clzDesc: ScalaTestClassDescriptor =>
-            logger.info("Start execution of suite class " + clzDesc.suiteClass.getName + "...")
+            logger.fine("Start execution of suite class " + clzDesc.suiteClass.getName + "...")
             listener.executionStarted(clzDesc)
             val suiteClass = clzDesc.suiteClass
             val canInstantiate = JUnitHelper.checkForPublicNoArgConstructor(suiteClass) && classOf[org.scalatest.Suite].isAssignableFrom(suiteClass)
@@ -327,7 +327,7 @@ class ScalaTestEngine extends org.junit.platform.engine.TestEngine {
 
             listener.executionFinished(clzDesc, TestExecutionResult.successful())
 
-            logger.info("Completed execution of suite class " + clzDesc.suiteClass.getName + ".")
+            logger.config("Completed execution of suite class " + clzDesc.suiteClass.getName + ".")
 
           case otherDesc =>
             // Do nothing for other descriptor, just log it.
@@ -335,7 +335,7 @@ class ScalaTestEngine extends org.junit.platform.engine.TestEngine {
         }
       }
       listener.executionFinished(engineDesc, TestExecutionResult.successful())
-      logger.info("Completed tests execution.")
+      logger.fine("Completed tests execution.")
     }
   }
 }

--- a/src/main/scala/org/scalatestplus/junit5/ScalaTestEngine.scala
+++ b/src/main/scala/org/scalatestplus/junit5/ScalaTestEngine.scala
@@ -21,11 +21,11 @@ import org.junit.platform.engine.support.descriptor.EngineDescriptor
 import org.junit.platform.engine.support.discovery.SelectorResolver.{Match, Resolution}
 import org.junit.platform.engine.support.discovery.{EngineDiscoveryRequestResolver, SelectorResolver}
 import org.junit.platform.engine.{EngineDiscoveryRequest, ExecutionRequest, TestDescriptor, TestExecutionResult, UniqueId}
-import org.scalatest.{Args, ConfigMap, DynaTags, Filter, ParallelTestExecution, Stopper, Suite, Tracker}
+import org.scalatest.{Args, ConfigMap, DynaTags, Filter, ParallelTestExecution, Stopper, Tracker}
 
 import java.lang.reflect.Modifier
 import java.util.concurrent.atomic.AtomicInteger
-import java.util.{Optional, UUID}
+import java.util.Optional
 import java.util.concurrent.{ExecutorService, Executors, ThreadFactory}
 import java.util.logging.Logger
 import java.util.stream.Collectors
@@ -107,7 +107,11 @@ class ScalaTestEngine extends org.junit.platform.engine.TestEngine {
               .stream()
               .flatMap(addToParentFunction(context))
               .collect(Collectors.toSet())
-          Resolution.matches(matches)
+          if (matches.isEmpty) {
+            Resolution.unresolved()
+          } else {
+            Resolution.matches(matches)
+          }
         }
 
         override def resolve(selector: PackageSelector, context: SelectorResolver.Context): SelectorResolver.Resolution = {
@@ -116,7 +120,11 @@ class ScalaTestEngine extends org.junit.platform.engine.TestEngine {
               .stream()
               .flatMap(addToParentFunction(context))
               .collect(Collectors.toSet())
-          Resolution.matches(matches)
+          if (matches.isEmpty) {
+            Resolution.unresolved()
+          } else {
+            Resolution.matches(matches)
+          }
         }
 
         override def resolve(selector: ModuleSelector, context: SelectorResolver.Context): SelectorResolver.Resolution = {
@@ -125,7 +133,11 @@ class ScalaTestEngine extends org.junit.platform.engine.TestEngine {
               .stream()
               .flatMap(addToParentFunction(context))
               .collect(Collectors.toSet())
-          Resolution.matches(matches)
+          if (matches.isEmpty) {
+            Resolution.unresolved()
+          } else {
+            Resolution.matches(matches)
+          }
         }
 
         override def resolve(selector: ClassSelector, context: SelectorResolver.Context): SelectorResolver.Resolution = {

--- a/src/test/scala/org/scalatestplus/junit5/ScalaTestEngineSpec.scala
+++ b/src/test/scala/org/scalatestplus/junit5/ScalaTestEngineSpec.scala
@@ -1,0 +1,65 @@
+package org.scalatestplus.junit5
+
+import org.junit.platform.engine.UniqueId
+import org.junit.platform.engine.discovery.ClasspathRootSelector
+import org.junit.platform.engine.discovery.DiscoverySelectors.{selectClasspathRoots, selectPackage}
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request
+import org.scalatest.{BeforeAndAfterAll, funspec}
+import org.scalatestplus.junit5.helpers.HappySuite
+
+import java.nio.file.{Files, Paths}
+import scala.collection.JavaConverters._
+
+class ScalaTestEngineSpec extends funspec.AnyFunSpec with BeforeAndAfterAll {
+  val engine = new ScalaTestEngine
+  var scalaTestEngineProperty: Option[String] = None
+
+  override def beforeAll(): Unit = {
+    scalaTestEngineProperty = Option(System.clearProperty("org.scalatestplus.junit5.ScalaTestEngine.disabled"))
+  }
+
+  override def afterAll(): Unit = {
+    scalaTestEngineProperty.foreach(System.setProperty("org.scalatestplus.junit5.ScalaTestEngine.disabled", _))
+  }
+
+  describe("ScalaTestEngine") {
+    describe("discover method") {
+      it("should discover suites on classpath") {
+        val classPathRoot = classOf[ScalaTestEngineSpec].getProtectionDomain.getCodeSource.getLocation
+        val discoveryRequest = request.selectors(
+          selectClasspathRoots(java.util.Collections.singleton(Paths.get(classPathRoot.toURI)))
+        ).build()
+        val engineDescriptor = engine.discover(discoveryRequest, UniqueId.forEngine(engine.getId()))
+        assert(engineDescriptor.getChildren.asScala.exists(td => td.asInstanceOf[ScalaTestClassDescriptor].suiteClass == classOf[HappySuite]))
+      }
+
+      it("should return unresolved for classpath without any tests") {
+        val emptyPath = Files.createTempDirectory(null)
+        val discoveryRequest = request.selectors(
+          selectClasspathRoots(java.util.Collections.singleton(emptyPath))
+        ).build()
+
+        val engineDescriptor = engine.discover(discoveryRequest, UniqueId.forEngine(engine.getId()))
+        assert(engineDescriptor.getChildren.asScala.isEmpty)
+      }
+
+      it("should discover suites in package") {
+        val discoveryRequest = request.selectors(
+          selectPackage("org.scalatestplus.junit5.helpers")
+        ).build()
+
+        val engineDescriptor = engine.discover(discoveryRequest, UniqueId.forEngine(engine.getId()))
+        assert(engineDescriptor.getChildren.asScala.exists(td => td.asInstanceOf[ScalaTestClassDescriptor].suiteClass == classOf[HappySuite]))
+      }
+
+      it("should return unresolved for package without any tests") {
+        val discoveryRequest = request.selectors(
+          selectPackage("org.scalatestplus.junit5.nonexistant")
+        ).build()
+
+        val engineDescriptor = engine.discover(discoveryRequest, UniqueId.forEngine(engine.getId()))
+        assert(engineDescriptor.getChildren.asScala.isEmpty)
+      }
+    }
+  }
+}


### PR DESCRIPTION
We have a project that has both java and scala tests in a multimodule maven project and we use junit5 to run all of them. We also use IntelliJ and this causes problems. When running tests on a whole module the ScalaTestEngine fails with an error at the bottom. As you can see it tries to discover tests using classpath root and IntelliJ, besides a test classes path adds a normal classes path. Obviously, there are no tests to discover there so when `Resolution.matches` is called at the end of `resolve` with an empty set it fails an assertion. Looking at other code for junit test engines it seems it should return `Resolution.unresolved()` to indicate that nothing was found. (see https://junit.org/junit5/docs/current/api/org.junit.platform.engine/org/junit/platform/engine/SelectorResolutionResult.Status.html).

To fix it I just applied a simple condition to check if the results are empty and return `unresolved` in such a case. I have also reduced log verbosity since it logs something that looks like debugging messages (at least I found it superfluous when they appeared in my test logs).

```
org.scalatestplus.junit5.ScalaTestEngine discover
INFO: Starting test discovery...
Internal Error occurred.
org.junit.platform.commons.JUnitException: TestEngine with ID 'scalatest' failed to discover tests
	at org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discoverEngineRoot(EngineDiscoveryOrchestrator.java:165)
	at org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discoverSafely(EngineDiscoveryOrchestrator.java:132)
	at org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discover(EngineDiscoveryOrchestrator.java:105)
	at org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discover(EngineDiscoveryOrchestrator.java:78)
	at org.junit.platform.launcher.core.DefaultLauncher.discover(DefaultLauncher.java:99)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:85)
	at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
	at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$1(InterceptingLauncher.java:39)
	at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
	at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:38)
	at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47)
	at org.junit.platform.launcher.core.SessionPerRequestLauncher.execute(SessionPerRequestLauncher.java:63)
	at com.intellij.junit5.JUnit5IdeaTestRunner.startRunnerWithArgs(JUnit5IdeaTestRunner.java:57)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:231)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:55)
Caused by: org.junit.platform.commons.JUnitException: ClasspathRootSelector [classpathRoot = file:///path/to/module/target/classes/] resolution failed
	at org.junit.platform.launcher.listeners.discovery.AbortOnFailureLauncherDiscoveryListener.selectorProcessed(AbortOnFailureLauncherDiscoveryListener.java:39)
	at org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolution.resolveCompletely(EngineDiscoveryRequestResolution.java:103)
	at org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolution.run(EngineDiscoveryRequestResolution.java:83)
	at org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolver.resolve(EngineDiscoveryRequestResolver.java:116)
	at org.scalatestplus.junit5.ScalaTestEngine.discover(ScalaTestEngine.scala:235)
	at org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discoverEngineRoot(EngineDiscoveryOrchestrator.java:152)
	... 17 more
Caused by: org.junit.platform.commons.PreconditionViolationException: matches must not be empty
	at org.junit.platform.commons.util.Preconditions.condition(Preconditions.java:298)
	at org.junit.platform.commons.util.Preconditions.notEmpty(Preconditions.java:143)
	at org.junit.platform.engine.support.discovery.SelectorResolver$Resolution.matches(SelectorResolver.java:490)
	at org.scalatestplus.junit5.ScalaTestEngine$$anon$6.resolve(ScalaTestEngine.scala:110)
	at org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolution.lambda$resolve$2(EngineDiscoveryRequestResolution.java:132)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1685)
	at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:129)
	at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:527)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:513)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:150)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.findFirst(ReferencePipeline.java:647)
	at org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolution.resolve(EngineDiscoveryRequestResolution.java:189)
	at org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolution.resolve(EngineDiscoveryRequestResolution.java:126)
	at org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolution.resolveCompletely(EngineDiscoveryRequestResolution.java:92)
	... 21 more
```