### PR TITLE
Fix class-level test selection running zero tests

### DIFF
--- a/src/main/scala/org/scalatestplus/junit5/ScalaTestEngine.scala
+++ b/src/main/scala/org/scalatestplus/junit5/ScalaTestEngine.scala
@@ -281,7 +281,7 @@ class ScalaTestEngine extends org.junit.platform.engine.TestEngine {
                   excludeNestedSuites = false,
                   dynaTags = DynaTags(Map.empty, Map(suiteToRun.suiteId -> Map.empty))
                 )
-              if (suiteToRun.testNames.size == children.size)  // When testNames size is same as children size, it means all tests are selected, so no need to apply filter, this solves the issue of dynamic test names when running suite.
+              else if (suiteToRun.testNames.size == children.size)  // When testNames size is same as children size, it means all tests are selected, so no need to apply filter, this solves the issue of dynamic test names when running suite.
                 Filter.default
               else {
                 val SelectedTag = "Selected"

--- a/src/test/scala/org/scalatestplus/junit5/ScalaTestEngineSpec.scala
+++ b/src/test/scala/org/scalatestplus/junit5/ScalaTestEngineSpec.scala
@@ -1,11 +1,12 @@
 package org.scalatestplus.junit5
 
-import org.junit.platform.engine.UniqueId
+import org.junit.platform.engine.{TestExecutionResult, UniqueId}
 import org.junit.platform.engine.discovery.ClasspathRootSelector
-import org.junit.platform.engine.discovery.DiscoverySelectors.{selectClasspathRoots, selectPackage}
+import org.junit.platform.engine.discovery.DiscoverySelectors.{selectClass, selectClasspathRoots, selectPackage}
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request
 import org.scalatest.{BeforeAndAfterAll, funspec}
 import org.scalatestplus.junit5.helpers.HappySuite
+
 
 import java.nio.file.{Files, Paths}
 import scala.collection.JavaConverters._
@@ -59,6 +60,20 @@ class ScalaTestEngineSpec extends funspec.AnyFunSpec with BeforeAndAfterAll {
 
         val engineDescriptor = engine.discover(discoveryRequest, UniqueId.forEngine(engine.getId()))
         assert(engineDescriptor.getChildren.asScala.isEmpty)
+      }
+    }
+
+    describe("execute method") {
+      it("should discover suite with no children when selected by class-level UniqueId") {
+        val engineId = UniqueId.forEngine(engine.getId())
+        val suiteUniqueId = engineId.append(ScalaTestClassDescriptor.segmentType, classOf[HappySuite].getName)
+        val discoveryRequest = request.selectors(
+          org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId(suiteUniqueId)
+        ).build()
+        val engineDescriptor = engine.discover(discoveryRequest, engineId)
+
+        val suiteDesc = engineDescriptor.getChildren.asScala.head.asInstanceOf[ScalaTestClassDescriptor]
+        assert(suiteDesc.getChildren.asScala.isEmpty)
       }
     }
   }


### PR DESCRIPTION
## Problem

When a test class is selected without specifying individual tests (e.g. by Develocity Predictive Test Selection, which selects at the class level), `children` is empty. In this case, `ScalaTestEngine.execute()` should run all tests in the suite, but instead runs zero tests while reporting the suite as PASSED.

### Root cause

The `filter` block in `execute()` has two independent `if` statements without an `else` chain:

```scala
val filter = {
    if (children.isEmpty)
        Filter(tagsToInclude = None, ...)   // result DISCARDED
    if (suiteToRun.testNames.size == children.size)
        Filter.default
    else { ... }
}
```

The first `if` creates a valid Filter but its result is discarded — in Scala, the block's value is the last expression, which is the second `if/else`. The second branch evaluates `testNames.size == 0` (false), falls to the `else`, builds a tag-based filter from the empty `children` set, and selects zero tests.

## Fix

Add `else` before the second `if` to create a proper `if/else if/else` chain:

```scala
if (children.isEmpty)
    Filter(tagsToInclude = None, ...)
else if (suiteToRun.testNames.size == children.size)
    Filter.default
else { ... }
```

This is a one-word change that preserves all the original logic — the `children.isEmpty` branch now correctly returns its Filter.

## Testing

Verified with Develocity Predictive Test Selection against a Gradle 9.3.1 project using ScalaTest 3.2.20 on Scala 2.12:
- **Before fix**: PTS selects a class, suite reports PASSED with 0 tests executed, broken tests are silently missed
- **After fix**: PTS selects a class, all 143 tests in the suite execute, 2 broken tests correctly fail the build